### PR TITLE
feat: 去掉example_test里面的相对路径引用

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -5,9 +5,10 @@
 package consistent_test
 
 import (
-	"../consistent"
 	"fmt"
 	"log"
+
+	"github.com/game1991/consistent"
 )
 
 func ExampleNew() {

--- a/example_test.go
+++ b/example_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/game1991/consistent"
+	"github.com/toolkits/consistent"
 )
 
 func ExampleNew() {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/game1991/consistent
+module github.com/toolkits/consistent
 
 go 1.22.6

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/game1991/consistent
+
+go 1.22.6

--- a/rings/rings.go
+++ b/rings/rings.go
@@ -1,7 +1,7 @@
 package rings
 
 import (
-	consistent "github.com/game1991/consistent"
+	consistent "github.com/toolkits/consistent"
 )
 
 // 一致性哈希环,用于管理服务器节点.

--- a/rings/rings.go
+++ b/rings/rings.go
@@ -1,7 +1,7 @@
 package rings
 
 import (
-	consistent "github.com/toolkits/consistent"
+	consistent "github.com/game1991/consistent"
 )
 
 // 一致性哈希环,用于管理服务器节点.


### PR DESCRIPTION
由于使用go mod模式进行引用依赖时，会受到相对路径的规范约束，所以去掉example_test文件中的相对路径引用